### PR TITLE
Fixing a mistranslation in the Chinese translations.

### DIFF
--- a/src/main/i18n/translations/zh.ts
+++ b/src/main/i18n/translations/zh.ts
@@ -67,7 +67,7 @@ const translationsZh: Translations = {
 
 	// Preferences
 	"diary-entries": "日记条目",
-	"allow-future-entries": "允许将来创建条目",
+	"allow-future-entries": "允许创建将来的条目",
 
 	// Password and directory
 	"change-directory": "更改路径",

--- a/src/main/i18n/translations/zhTw.ts
+++ b/src/main/i18n/translations/zhTw.ts
@@ -67,7 +67,7 @@ const translationsZhTw: Translations = {
 	"search": "搜尋",
 
 	// Preferences
-	"allow-future-entries": "允許未來新增條目",
+	"allow-future-entries": "允許新增未來的條目",
 	"diary-entries": "日記條目",
 	"no": "取消",
 	"reset-diary": "重置日記本",


### PR DESCRIPTION
The "allow-future-entries" in both Chinese translations (`zh.ts` and `zhTw.ts`)  may lead to some misunderstanding. I have updated it for both translations.